### PR TITLE
lightning 2.0.9post0 b1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   entry_points:
     - lightning = lightning.app.cli.lightning_cli:main
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
-  number: 0
+  number: 1
   # Skip on linux-s390x because lightning-cloud isn't available.
   skip: true  # [py<38 or s390x]
 


### PR DESCRIPTION
lightning 2.0.9post0 b1

**Destination channel:** defaults

### Links

- [PKG-6435](https://anaconda.atlassian.net/browse/PKG-6435)

### Explanation of changes:

- Rebuild to get `py312` artifact for `linux-64`


[PKG-6435]: https://anaconda.atlassian.net/browse/PKG-6435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ