### PR TITLE
v2.5.0.post0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/pytorch-lightning-feedstock/pr10/2114169

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
-
-channels:
-  - https://staging.continuum.io/prefect/fs/pytorch-lightning-feedstock/pr10/2114169

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lightning" %}
-{% set version = "2.3.3" %}
+{% set version = "2.5.0.post0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7f454711895c1c6e455766f01fa39522e25e5ab54c15c5e5fbad342fa92bc93c
+  sha256: f720fe4f6d03a7f15f9aef3112c5a0d1eafd8d27b903f4a1354b609685b2ec70
 
 build:
   entry_points:
@@ -15,7 +15,7 @@ build:
     - lightning = lightning.fabric.cli:_legacy_main
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   number: 0
-  skip: true  # [py<38]
+  skip: true  # [py<39]
 
 requirements:
   host:
@@ -37,7 +37,7 @@ requirements:
     - lightning-utilities >=0.10.0,<2.0
     - numpy >=1.17.2,<3.0
     - packaging >=20.0,<25.0
-    - pytorch >=2.0.0,<4.0
+    - pytorch >=2.1.0,<4.0
     - torchmetrics >=0.7.0,<3.0
     - tqdm >=4.57.0,<6.0
     - typing-extensions >=4.4.0,<6.0


### PR DESCRIPTION
lightning v2.5.0.post0

**Destination channel:**  defaults

### Links

- [PKG-7172](https://anaconda.atlassian.net/browse/PKG-7172) 
- [Upstream repository](https://github.com/Lightning-AI/pytorch-lightning/tree/2.5.0.post0)
- [Upstream changelog/diff](https://github.com/Lightning-AI/pytorch-lightning/compare/2.3.3...2.5.0.post0)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/pytorch-lightning-feedstock/pull/10

### Explanation of changes:

- Bump version and SHA
- Upstream dropped the support for 3.8
- Adds staging channel to build against latest `pytorch-lightning`
- Update the dependency pinnings. Note the comment:

```
    # The pinnings below are extracted from lightning.egg-info/requires.txt
    # This is because the requirements under requirements/ are transformed
    # before being used by the setup script
```

I used the METADATA file inside of the [Wheel](https://files.pythonhosted.org/packages/d4/54/2de887e964a561776ac49c5e715ca8a56138ea7e2b95325e0a79aa46a070/lightning-2.5.0.post0-py3-none-any.whl). I attached it here:
[METADATA.txt](https://github.com/user-attachments/files/19059720/METADATA.txt)



[PKG-7172]: https://anaconda.atlassian.net/browse/PKG-7172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ