### PR TITLE
lightning 2.6.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - pyyaml >=5.4,<8.0
     - fsspec >=2022.5.0,<2027.0
     - aiohttp !=4.0.0a0,!=4.0.0a1
-    #- requests
+    - requests
     - lightning-utilities >=0.10.0,<2.0
     - packaging >=20.0,<27.0
     # By default pytorch try to resolve gpu version:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,12 @@ requirements:
     # click is necessary to use the entry-points
     - click
 
+# >   raise RuntimeError("Bitsandbytes is only supported on CUDA GPUs.")
+# E   RuntimeError: Bitsandbytes is only supported on CUDA GPUs.
+{% set deselect_tests = " --deselect=gh_src/tests/tests_fabric/plugins/precision/test_bitsandbytes.py::test_bitsandbytes_plugin" %}
+# >   os.symlink(source, dest)
+# E   OSError: [WinError 1314] A required privilege is not held by the client: '.\\lightning_logs' -> '.\\sym_lightning_logs'
+{% set deselect_tests = deselect_tests + " --deselect=gh_src/tests/tests_fabric/loggers/test_tensorboard.py::test_tensorboard_with_symlink" %}  # [win]
 test:
   source_files:
     - gh_src/tests
@@ -55,12 +61,12 @@ test:
   commands:
     - pip check
     - fabric --help
-    - pytest -v gh_src/tests/tests_fabric
+    - pytest -v gh_src/tests/tests_fabric {{ deselect_tests }}  # [py<313]
   requires:
     - pip
     - pytest ==8.4.2
     - cloudpickle >=1.3,<4.0
-    - tensorboard >=2.11,<3.0
+    - tensorboard >=2.11,<3.0  # [py<313]
 
 about:
   home: https://github.com/Lightning-AI/pytorch-lightning

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,20 +1,22 @@
 {% set name = "lightning" %}
-{% set version = "2.5.0.post0" %}
+{% set version = "2.6.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f720fe4f6d03a7f15f9aef3112c5a0d1eafd8d27b903f4a1354b609685b2ec70
+  - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: 881841716b59c1837ae0c562c2e64fea9bcf49ef9de3867bd1f868557ec23d04
+  - url: https://github.com/Lightning-AI/pytorch-{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+    sha256: 2761a16d362ac604798e230883a81b54ed301ef45eea4b93a58ced79feb50760
+    folder: gh_src
 
 build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   entry_points:
     - fabric = lightning.fabric.cli:_main
-    - lightning = lightning.fabric.cli:_legacy_main
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
-  number: 0
   skip: true  # [py<39]
 
 requirements:
@@ -23,37 +25,43 @@ requirements:
     - python
     - setuptools
     - wheel
+    - packaging
   run:
     - python
-    # The pinnings below are extracted from lightning.egg-info/requires.txt
+    # The pinnings below are extracted from src/lightning.egg-info/requires.txt
     # This is because the requirements under requirements/ are transformed
     # before being used by the setup script
     - pyyaml >=5.4,<8.0
-    ## fsspec[http] ##
-    - fsspec >=2022.5.0,<2026.0
+    - fsspec >=2022.5.0,<2027.0
     - aiohttp !=4.0.0a0,!=4.0.0a1
-    - requests
-    ## fsspec[http] ##
+    #- requests
     - lightning-utilities >=0.10.0,<2.0
-    - numpy >=1.17.2,<3.0
-    - packaging >=20.0,<25.0
-    - pytorch >=2.1.0,<4.0
+    #- numpy >=1.17.2,<3.0
+    - packaging >=20.0,<27.0
+    # By default pytorch try to resolve gpu version:
+    # Trying to find MPS symbol : _C.cpython-310-darwin.so, 0x0002: Symbol not found: __ZN2at3mps14getMPSProfilerEv
+    - pytorch-cpu >=2.1.0,<4.0
     - torchmetrics >=0.7.0,<3.0
     - tqdm >=4.57.0,<6.0
-    - typing-extensions >=4.4.0,<6.0
+    - typing-extensions >=4.5.0,<6.0
     - pytorch-lightning
     # click is necessary to use the entry-points
     - click
 
 test:
+  source_files:
+    - gh_src/tests
   imports:
     - lightning
   commands:
     - pip check
-    - lightning --help
     - fabric --help
+    - pytest -v gh_src/tests/tests_fabric
   requires:
     - pip
+    - pytest ==8.4.2
+    - cloudpickle >=1.3,<4.0
+    - tensorboard >=2.11,<3.0
 
 about:
   home: https://github.com/Lightning-AI/pytorch-lightning
@@ -64,7 +72,7 @@ about:
   license_file:
     - LICENSE
   dev_url: https://github.com/Lightning-AI/pytorch-lightning
-  doc_url: https://lightning.ai/docs/app/stable/
+  doc_url: https://lightning.ai/docs/app/stable
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,6 @@ requirements:
     - aiohttp !=4.0.0a0,!=4.0.0a1
     #- requests
     - lightning-utilities >=0.10.0,<2.0
-    #- numpy >=1.17.2,<3.0
     - packaging >=20.0,<27.0
     # By default pytorch try to resolve gpu version:
     # Trying to find MPS symbol : _C.cpython-310-darwin.so, 0x0002: Symbol not found: __ZN2at3mps14getMPSProfilerEv


### PR DESCRIPTION
lightning 2.6.0 

**Destination channel:** Defaults

### Links

- [PKG-11045]
- dev_url:        https://github.com/Lightning-AI/pytorch-lightning/tree/2.6.0
- conda_forge:    https://github.com/conda-forge/lightning-feedstock
- pypi:           https://pypi.org/project/lightning/2.6.0
- pypi inspector: https://inspector.pypi.io/project/lightning/2.6.0

### Explanation of changes:

- new version number


[PKG-11045]: https://anaconda.atlassian.net/browse/PKG-11045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ